### PR TITLE
Fix csv write error

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+wb-mqtt-db-cli (1.4.3) stable; urgency=medium
+
+  * Fix broken `-o/--output-fname` option
+  * Add `--max-records` option
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Fri, 27 Jan 2023 15:21:00 +0400
+
 wb-mqtt-db-cli (1.4.2) stable; urgency=medium
 
   * Code formatting

--- a/wb-mqtt-db-cli.py
+++ b/wb-mqtt-db-cli.py
@@ -1,5 +1,5 @@
-#!/usr/bin/python3
-# import pprint
+#!/usr/bin/env python3
+
 import argparse
 import csv
 import datetime
@@ -82,6 +82,14 @@ def main():
         dest="auto_interval",
         action="store_true",
         help='Automatically estimate the interval between data points based on "limit", "from" and "start"',
+    )
+
+    parser.add_argument(
+        "--max-records",
+        dest="max_records",
+        type=int,
+        help="Max number of records within interval",
+        default=None,
     )
 
     parser.add_argument(
@@ -172,7 +180,7 @@ def main():
     if args.output_fname == "-":
         csvfile = sys.stdout
     else:
-        csvfile = open(args.output_fname, "wb")
+        csvfile = open(args.output_fname, "w")
 
     try:
         writer = csv.DictWriter(csvfile, fieldnames=fieldnames, delimiter=args.delimiter)
@@ -185,15 +193,19 @@ def main():
                 "timestamp": {},
                 "limit": args.limit,
                 "ver": 1,
+                "with_milliseconds": True,
             }
 
             if args.date_from:
                 rpc_params["timestamp"]["gt"] = int(time.mktime(date_from.timetuple()))
             if args.date_to:
-                rpc_params["timestamp"]["lt"] = time.mktime(date_to.timetuple())
+                rpc_params["timestamp"]["lt"] = int(time.mktime(date_to.timetuple()))
 
             if min_interval:
                 rpc_params["min_interval"] = min_interval
+
+            if args.max_records:
+                rpc_params["max_records"] = args.max_records
 
             if args.timeout:
                 rpc_params["request_timeout"] = args.timeout


### PR DESCRIPTION
```sh
wb-mqtt-db-cli --from "2023-01-25" --to "2023-01-27" -o file.csv buzzer/volume
Traceback (most recent call last):
  File "/usr/bin/wb-mqtt-db-cli", line 240, in <module>
    main()
  File "/usr/bin/wb-mqtt-db-cli", line 216, in main
    writer.writeheader()
  File "/usr/lib/python3.9/csv.py", line 143, in writeheader
    return self.writerow(header)
  File "/usr/lib/python3.9/csv.py", line 154, in writerow
    return self.writer.writerow(self._dict_to_list(rowdict))
TypeError: a bytes-like object is required, not 'str'
```