### PR TITLE
Use mqtt client wrapper from wb-common

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,9 @@
 .PHONY: all clean
 
+PREFIX = /usr
+
 all:
 clean :
 
 install: all
-	mkdir -p $(DESTDIR)/usr/bin
-	install -m 0755 	wb-mqtt-db-cli.py $(DESTDIR)/usr/bin/wb-mqtt-db-cli
-
-
-
-
-
-
+	install -Dm0755 wb-mqtt-db-cli.py $(DESTDIR)$(PREFIX)/bin/wb-mqtt-db-cli

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Examples
 Outputs at max 10 points per channel trying to evenly distribute the data points. Note the "-a" switch.
 
 
-```
-$ wb-mqtt-db-cli -h 192.168.0.175 --from "2017-06-01" --to "2017-06-02" --decimal-places 2 --limit 10 -a  wb-adc/5Vout wb-adc/Vin
+```sh
+$ wb-mqtt-db-cli -b tcp://192.168.0.175:1883 --from "2017-06-01" --to "2017-06-02" --decimal-places 2 --limit 10 -a  wb-adc/5Vout wb-adc/Vin
 channel time    average min max
 wb-adc/5Vout    2017-06-01 00:00:46.269996  5.10    5.09    5.11
 wb-adc/5Vout    2017-06-01 00:24:46.311995  5.10    5.09    5.11
@@ -33,8 +33,8 @@ wb-adc/Vin  2017-06-01 12:18:58.514002  11.98   11.93   12.02
 Without "-a" switch the behaviour is different: only the first 10 data points are returned:
 
 
-```
-wb-mqtt-db-cli -h 192.168.0.175 --from "2017-06-01" --decimal-places 2 --limit 10  wb-adc/5Vout 
+```sh
+wb-mqtt-db-cli -b tcp://192.168.0.175:1883 --from "2017-06-01" --decimal-places 2 --limit 10  wb-adc/5Vout
 channel time    average min max
 wb-adc/5Vout    2017-06-01 00:00:46.269996  5.10    5.09    5.11
 wb-adc/5Vout    2017-06-01 00:02:46.265000  5.10    5.09    5.11
@@ -50,8 +50,8 @@ wb-adc/5Vout    2017-06-01 00:18:46.264983  5.10    5.09    5.11
 
 The custom delimiter can be specified using "-d" switch:
 
-```
-$ wb-mqtt-db-cli -h 192.168.0.175 --from "2017-06-01" --limit 5 -d';'  wb-adc/5Vout  
+```sh
+$ wb-mqtt-db-cli -b tcp://192.168.0.175:1883 --from "2017-06-01" --limit 5 -d';'  wb-adc/5Vout
 channel;time;average;min;max
 wb-adc/5Vout;2017-06-01 00:00:46.269996;5.10218045112783;5.09;5.11
 wb-adc/5Vout;2017-06-01 00:02:46.265000;5.10255639097746;5.09;5.11
@@ -62,8 +62,8 @@ wb-adc/5Vout;2017-06-01 00:08:46.262002;5.10142857142858;5.09;5.11
 
 Custom time format example:
 
-```
-$ wb-mqtt-db-cli -h 192.168.0.175 --from "2017-06-01" --time-format="%Y/%m/%d %H:%M:%S" --decimal-places 2 --limit 10  wb-adc/5Vout 
+```sh
+$ wb-mqtt-db-cli -b tcp://192.168.0.175:1883 --from "2017-06-01" --time-format="%Y/%m/%d %H:%M:%S" --decimal-places 2 --limit 10  wb-adc/5Vout
 channel time    average min max
 wb-adc/5Vout    2017/06/01 00:00:46 5.10    5.09    5.11
 wb-adc/5Vout    2017/06/01 00:02:46 5.10    5.09    5.11

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-mqtt-db-cli (1.4.4) stable; urgency=medium
+
+  * Use mqtt client wrapper from wb-common
+
+ -- Nikolay Korotkiy <nikolay.korotkiy@wirenboard.com>  Tue, 28 Feb 2023 18:39:00 +0400
+
 wb-mqtt-db-cli (1.4.3) stable; urgency=medium
 
   * Fix broken `-o/--output-fname` option

--- a/debian/control
+++ b/debian/control
@@ -8,5 +8,5 @@ Homepage: https://github.com/wirenboard/wb-mqtt-db-cli
 
 Package: wb-mqtt-db-cli
 Architecture: all
-Depends: ${shlibs:Depends}, ${misc:Depends}, python3-mqttrpc (>= 1.1), python3-dateutil, python3-paho-mqtt, python3-paho-socket
+Depends: ${shlibs:Depends}, ${misc:Depends}, python3-mqttrpc (>= 1.1), python3-dateutil, python3-wb-common (>= 2.1.0)
 Description: CLI for wb-mqtt-db

--- a/wb-mqtt-db-cli.py
+++ b/wb-mqtt-db-cli.py
@@ -7,8 +7,8 @@ import sys
 import time
 
 import dateutil.parser
-from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 from mqttrpc.client import MQTTRPCError, TMQTTRPCClient
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 
 
 def format_value(value_str, decimal_places=None):

--- a/wb-mqtt-db-cli.py
+++ b/wb-mqtt-db-cli.py
@@ -5,11 +5,9 @@ import csv
 import datetime
 import sys
 import time
-import urllib.parse
 
 import dateutil.parser
-import paho.mqtt.client as mqtt
-import paho_socket
+from wb_common.mqtt_client import DEFAULT_BROKER_URL, MQTTClient
 from mqttrpc.client import MQTTRPCError, TMQTTRPCClient
 
 
@@ -32,19 +30,13 @@ def main():
     parser.add_argument("--help", action="help", help="show this help message and exit")
 
     parser.add_argument(
-        "-h",
-        "--host",
-        dest="host",
+        "-b",
+        "--broker",
+        dest="broker_url",
         type=str,
-        help="MQTT host",
-        default="unix:///var/run/mosquitto/mosquitto.sock",
+        help="MQTT broker url",
+        default=DEFAULT_BROKER_URL,
     )
-
-    parser.add_argument("-u", "--username", dest="username", type=str, help="MQTT username", default="")
-
-    parser.add_argument("-P", "--password", dest="password", type=str, help="MQTT password", default="")
-
-    parser.add_argument("-p", "--port", dest="port", type=int, help="MQTT port", default="1883")
 
     parser.add_argument("--from", dest="date_from", type=str, help="start date", default=None)
 
@@ -157,22 +149,10 @@ def main():
             parser.error("--from is greater than --to (or in future)")
         min_interval = (time_interval / args.limit).total_seconds() * 1000
 
-    url = urllib.parse.urlparse(args.host)
-    if url.scheme == "unix":
-        client = paho_socket.Client("wb-mqtt-db-cli")
-        if args.username:
-            client.username_pw_set(args.username, args.password)
-        client.sock_connect(url.path)
-    else:
-        client = mqtt.Client("wb-mqtt-db-cli")
-        if args.username:
-            client.username_pw_set(args.username, args.password)
-        client.connect(args.host, args.port)
-
-    client.loop_start()
-
+    client = MQTTClient("wb-mqtt-db-cli", args.broker_url)
     rpc_client = TMQTTRPCClient(client)
     client.on_message = rpc_client.on_mqtt_message
+    client.connect()
 
     channels = [channel.split("/", 2) for channel in args.channels]
 
@@ -245,7 +225,7 @@ def main():
 
                 writer.writerow(csvrow)
     finally:
-        client.loop_stop()
+        client.disconnect()
         csvfile.close()
 
 

--- a/wb-mqtt-db-cli.py
+++ b/wb-mqtt-db-cli.py
@@ -152,7 +152,7 @@ def main():
     client = MQTTClient("wb-mqtt-db-cli", args.broker_url)
     rpc_client = TMQTTRPCClient(client)
     client.on_message = rpc_client.on_mqtt_message
-    client.connect()
+    client.start()
 
     channels = [channel.split("/", 2) for channel in args.channels]
 
@@ -225,7 +225,7 @@ def main():
 
                 writer.writerow(csvrow)
     finally:
-        client.disconnect()
+        client.stop()
         csvfile.close()
 
 


### PR DESCRIPTION
Depends on https://github.com/wirenboard/wb-common/pull/8

Test instructions:
```sh
$ wb-mqtt-db-cli --from "2023-02-10" --to "2023-03-01" metrics/ram_used
channel	time	average	min	max
metrics/ram_used	2023-02-28 23:59:00.628000	247	246	250
$ wb-mqtt-db-cli --from "2023-02-10" --to "2023-03-01" -b unix:///var/run/mosquitto/mosquitto.sock metrics/ram_used
channel	time	average	min	max
metrics/ram_used	2023-02-28 23:59:00.628000	247	246	250
$ wb-mqtt-db-cli --from "2023-02-10" --to "2023-03-01" -b tcp://127.0.0.1:1883 metrics/ram_used
channel	time	average	min	max
metrics/ram_used	2023-02-28 23:59:00.628000	247	246	250
$ wb-mqtt-db-cli --from "2023-02-10" --to "2023-03-01" -b tcp://user:password@127.0.0.1:1883 metrics/ram_used
channel	time	average	min	max
metrics/ram_used	2023-02-28 23:59:00.628000	247	246	250
$ wb-mqtt-db-cli --from "2023-02-10" --to "2023-03-01" -b ws://127.0.0.1:18883 metrics/ram_used
channel	time	average	min	max
metrics/ram_used	2023-02-28 23:59:00.628000	247	246	250
```